### PR TITLE
add orphans API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,3 +237,16 @@ This endpoint is designed to be used to check the health of redx. When you hit t
 ```
 curl localhost:8081/health
 ```
+
+### (GET|DELETE) /orphans
+Will return or delete any frontends and backends that are orphans. Meaning a list of any frontends that point to a missing backend, or any backends that don't have a frontend pointing to it.
+
+##### `GET` example
+```
+curl localhost:8081/orphans
+```
+
+##### `DELETE` example
+```
+curl -X DELETE localhost:8081/orphans
+```

--- a/lua/spec/api_spec.lua
+++ b/lua/spec/api_spec.lua
@@ -257,8 +257,56 @@ return describe("redx_api", function()
     response, code, headers = make_json_request("/backends/5555")
     return assert.same(404, code)
   end)
-  return it("should test healthcheck", function()
+  it("should test healthcheck", function()
     local response, code, headers = make_json_request("/health")
     return assert.same(200, code)
+  end)
+  it("should get orphans #orphans_api", function()
+    local response, code, headers = make_json_request("/backends/5555/" .. tostring(escape('rstudio.com:80')), "POST")
+    assert.same(200, code)
+    response, code, headers = make_json_request("/backends/5555/" .. tostring(escape('rstudio.com:80')), "POST")
+    assert.same(200, code)
+    response, code, headers = make_json_request("/frontends/" .. tostring(escape('foobar.com/path')) .. "/foobar", "POST")
+    assert.same(200, code)
+    response, code, headers = make_json_request("/orphans", "GET")
+    assert.same(200, code)
+    return assert.same(response['data'], {
+      backends = {
+        {
+          name = '5555'
+        }
+      },
+      frontends = {
+        {
+          url = 'foobar.com/path'
+        }
+      }
+    })
+  end)
+  return it("should delete orphans #orphans_api", function()
+    local response, code, headers = make_json_request("/backends/5555/" .. tostring(escape('rstudio.com:80')), "POST")
+    assert.same(200, code)
+    response, code, headers = make_json_request("/backends/5555/" .. tostring(escape('rstudio.com:80')), "POST")
+    assert.same(200, code)
+    response, code, headers = make_json_request("/frontends/" .. tostring(escape('foobar.com/path')) .. "/foobar", "POST")
+    assert.same(200, code)
+    response, code, headers = make_json_request("/orphans", "DELETE")
+    assert.same(200, code)
+    assert.same(response['data'], {
+      backends = {
+        {
+          name = '5555'
+        }
+      },
+      frontends = {
+        {
+          url = 'foobar.com/path'
+        }
+      }
+    })
+    response, code, headers = make_json_request("/backends/5555", "GET")
+    assert.same(404, code)
+    response, code, headers = make_json_request("/frontends/" .. tostring(escape('foobar.com/path')), "GET")
+    return assert.same(404, code)
   end)
 end)

--- a/lua/src/bin/api.lua
+++ b/lua/src/bin/api.lua
@@ -42,6 +42,23 @@ do
         }
       end
     }),
+    ['/orphans'] = respond_to({
+      GET = function(self)
+        redis.orphans(self)
+        return {
+          status = self.status,
+          json = json_response(self)
+        }
+      end,
+      DELETE = function(self)
+        local orphans = redis.orphans(self)
+        redis.delete_batch_data(self, orphans)
+        return {
+          status = self.status,
+          json = json_response(self)
+        }
+      end
+    }),
     ['/batch'] = respond_to({
       before = function(self)
         for k, v in pairs(self.req.params_post) do

--- a/lua/src/lib/library.lua
+++ b/lua/src/lib/library.lua
@@ -20,4 +20,11 @@ M.split = function(str, delim)
   end
   return _accum_0
 end
+M.Set = function(list)
+  local set = { }
+  for _, l in ipairs(list) do
+    set[l] = true
+  end
+  return set
+end
 return M

--- a/spec/api_spec.moon
+++ b/spec/api_spec.moon
@@ -231,3 +231,34 @@ describe "redx_api", ->
     it "should test healthcheck", ->
         response, code, headers = make_json_request("/health")
         assert.same 200, code
+
+    it "should get orphans #orphans_api", ->
+        response, code, headers = make_json_request("/backends/5555/#{escape('rstudio.com:80')}", "POST")
+        assert.same 200, code
+
+        response, code, headers = make_json_request("/backends/5555/#{escape('rstudio.com:80')}", "POST")
+        assert.same 200, code
+        response, code, headers = make_json_request("/frontends/#{escape('foobar.com/path')}/foobar", "POST")
+        assert.same 200, code
+
+        response, code, headers = make_json_request("/orphans", "GET")
+        assert.same 200, code
+        assert.same response['data'], { backends: {{ name: '5555' }}, frontends: {{ url: 'foobar.com/path' }} }
+
+    it "should delete orphans #orphans_api", ->
+        response, code, headers = make_json_request("/backends/5555/#{escape('rstudio.com:80')}", "POST")
+        assert.same 200, code
+
+        response, code, headers = make_json_request("/backends/5555/#{escape('rstudio.com:80')}", "POST")
+        assert.same 200, code
+        response, code, headers = make_json_request("/frontends/#{escape('foobar.com/path')}/foobar", "POST")
+        assert.same 200, code
+
+        response, code, headers = make_json_request("/orphans", "DELETE")
+        assert.same 200, code
+        assert.same response['data'], { backends: {{ name: '5555' }}, frontends: {{ url: 'foobar.com/path' }} }
+
+        response, code, headers = make_json_request("/backends/5555", "GET")
+        assert.same 404, code
+        response, code, headers = make_json_request("/frontends/#{escape('foobar.com/path')}", "GET")
+        assert.same 404, code

--- a/src/bin/api.moon
+++ b/src/bin/api.moon
@@ -21,6 +21,16 @@ webserver = class extends lapis.Application
             status: @status, json: json_response(@)
     }
 
+    '/orphans': respond_to {
+        GET: =>
+            redis.orphans(@)
+            status: @status, json: json_response(@)
+        DELETE: =>
+            orphans = redis.orphans(@)
+            redis.delete_batch_data(@, orphans)
+            status: @status, json: json_response(@)
+    }
+
     '/batch': respond_to {
         before: =>
             for k,v in pairs @req.params_post do

--- a/src/lib/library.moon
+++ b/src/lib/library.moon
@@ -12,4 +12,10 @@ M.split = (str, delim using nil) ->
   str ..= delim
   [part for part in str\gmatch "(.-)" .. escape_pattern delim]
 
+M.Set = (list) ->
+  set = {}
+  for _, l in ipairs(list) do
+    set[l] = true
+  return set
+
 return M


### PR DESCRIPTION
This will cause redx to search through its frontends and backends looking for any orphans. An orphaned frontend is defined as a frontend that points to a non-existent backend. And an orphaned backend is defined as a backend that has no frontend pointing to it.

I've updated the README in this PR as well as wrote a couple tests for the orphans API endpoint.
