### PR TITLE
add stickiness feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ Say in your service, your path always consists of an account name and service na
 
 Currently max_path_length must be a minimum of 1, but that will change in the future.
 
+##### stickiness
+The amount of time (in seconds) you wish the session to be "sticky", and consistently use the same upstream server. If you wish to disable "stickiness", set value to 0 (zero).
+
 API
 ===
 

--- a/conf/config.moon
+++ b/conf/config.moon
@@ -25,4 +25,8 @@ M.redis_keepalive_max_idle_timeout = 10000
 -- 3 = host.com/contact/us/now
 M.max_path_length = 1
 
+-- Stickiness
+-- Amount of time (in seconds) you wish the session to be sticky
+-- Set to 0 if you want to disable stickiness
+M.stickiness = 900
 return M

--- a/lua/conf/config.lua
+++ b/lua/conf/config.lua
@@ -6,4 +6,5 @@ M.redis_timeout = 5000
 M.redis_keepalive_pool_size = 0
 M.redis_keepalive_max_idle_timeout = 10000
 M.max_path_length = 1
+M.stickiness = 900
 return M


### PR DESCRIPTION
Adds support for "stickiness" by using [http cookies](http://en.wikipedia.org/wiki/HTTP_cookie). "Stickiness" is a feature that can be enabled (or disabled) that causes an individual user to alway go to the same backend server.
