### PR TITLE
Fix stickiness plugin by using frontend URL for cookie path

### DIFF
--- a/lua/src/bin/main.lua
+++ b/lua/src/bin/main.lua
@@ -111,24 +111,6 @@ end
 do
   local _parent_0 = lapis.Application
   local _base_0 = {
-    cookie_attributes = function(self, name, value)
-      local path = self.req.parsed_url['path']
-      local path_parts = library.split(path, '/')
-      local p = ''
-      local count = 0
-      for k, v in pairs(path_parts) do
-        if not (v == nil or v == '') then
-          if count < (config.max_path_length) then
-            count = count + 1
-            p = p .. "/" .. tostring(v)
-          end
-        end
-      end
-      if p == '' then
-        p = '/'
-      end
-      return "Max-Age=" .. tostring(config.session_length) .. "; Path=" .. tostring(p) .. "; HttpOnly"
-    end,
     ['/'] = function(self)
       return process_response(process_request(self))
     end,

--- a/lua/src/lib/plugins/stickiness.lua
+++ b/lua/src/lib/plugins/stickiness.lua
@@ -11,7 +11,7 @@ M.get_cookie = function(request, settings)
 end
 M.set_cookie = function(server, frontend, settings)
   local name = settings.COOKIE
-  local value = base64.encode(server.address)
+  local value = base64.encode(server)
   local path = M.extract_path(frontend)
   local cookie = tostring(url.escape(name)) .. "=" .. tostring(url.escape(value)) .. "; Path=" .. tostring(path) .. "; HttpOnly"
   ngx.log(ngx.DEBUG, "Setting sticky server: " .. tostring(value) .. " (Path=" .. tostring(path) .. ")")
@@ -40,7 +40,7 @@ M.post = function(request, session, settings)
   if session.server ~= nil then
     local current_server = M.extract_domain(session.server)
     if sticky_server ~= current_server then
-      return M.set_cookie(session.server, session.frontend, settings)
+      return M.set_cookie(current_server, session.frontend, settings)
     end
   end
 end

--- a/lua/src/lib/plugins/stickiness.lua
+++ b/lua/src/lib/plugins/stickiness.lua
@@ -15,7 +15,7 @@ M.set_cookie = function(request, server, frontend, settings)
   local path = M.extract_path(frontend)
   local cookie = tostring(url.escape(name)) .. "=" .. tostring(url.escape(value)) .. "; Path=" .. tostring(path) .. "; HttpOnly"
   ngx.log(ngx.DEBUG, "Setting sticky server: " .. tostring(server) .. " (Path=" .. tostring(path) .. ")")
-  ngx.headers['Set-Cookie'] = cookie
+  ngx.header['Set-Cookie'] = cookie
 end
 M.clear_cookie = function(request, settings)
   request.cookies[settings.COOKIE] = nil

--- a/lua/src/lib/plugins/stickiness.lua
+++ b/lua/src/lib/plugins/stickiness.lua
@@ -1,17 +1,47 @@
+local url = require('socket.url')
+local base64 = require('base64')
 local M = { }
-M.balance = function(request, session, param)
-  local _list_0 = session['servers']
-  for _index_0 = 1, #_list_0 do
-    local server = _list_0[_index_0]
-    if request.session.backend == M.extract_domain(server['address']) then
-      return server
+M.get_cookie = function(request, settings)
+  local cookie = request.cookies[settings.COOKIE]
+  if cookie ~= nil then
+    return base64.decode(cookie)
+  else
+    return nil
+  end
+end
+M.set_cookie = function(server, frontend, settings)
+  local name = settings.COOKIE
+  local value = base64.encode(server.address)
+  local path = M.extract_path(frontend)
+  local cookie = tostring(url.escape(name)) .. "=" .. tostring(url.escape(value)) .. "; Path=" .. tostring(path) .. "; HttpOnly"
+  ngx.log(ngx.DEBUG, "Setting sticky server: " .. tostring(value) .. " (Path=" .. tostring(path) .. ")")
+  return ngx.req.set_header('Set-Cookie', cookie)
+end
+M.clear_cookie = function(request, settings)
+  request.cookies[settings.COOKIE] = nil
+end
+M.balance = function(request, session, settings)
+  local sticky_server = M.get_cookie(request, settings)
+  if sticky_server ~= nil then
+    local _list_0 = session.servers
+    for _index_0 = 1, #_list_0 do
+      local server = _list_0[_index_0]
+      if sticky_server == M.extract_domain(server.address) then
+        return server
+      end
     end
+    ngx.log(ngx.WARN, "Server not found matching address: " .. tostring(sticky_server))
+    M.clear_cookie(request, settings)
   end
   return session['servers']
 end
-M.post = function(request, session, param)
-  if session['server'] then
-    request.session.backend = M.extract_domain(session['server'])
+M.post = function(request, session, settings)
+  local sticky_server = M.get_cookie(request, settings)
+  if session.server ~= nil then
+    local current_server = M.extract_domain(session.server.address)
+    if sticky_server ~= current_server then
+      return M.set_cookie(session.server, session.frontend, settings)
+    end
   end
 end
 M.extract_domain = function(url)
@@ -21,6 +51,14 @@ M.extract_domain = function(url)
     local location_index = string.find(url, '/')
     local domain = string.sub(url, 1, (location_index - 1))
     return domain
+  end
+end
+M.extract_path = function(url)
+  local i = string.find(url, '/')
+  if i ~= nil then
+    return string.sub(url, i)
+  else
+    return '/'
   end
 end
 return M

--- a/lua/src/lib/plugins/stickiness.lua
+++ b/lua/src/lib/plugins/stickiness.lua
@@ -38,7 +38,7 @@ end
 M.post = function(request, session, settings)
   local sticky_server = M.get_cookie(request, settings)
   if session.server ~= nil then
-    local current_server = M.extract_domain(session.server.address)
+    local current_server = M.extract_domain(session.server)
     if sticky_server ~= current_server then
       return M.set_cookie(session.server, session.frontend, settings)
     end

--- a/lua/src/lib/plugins/stickiness.lua
+++ b/lua/src/lib/plugins/stickiness.lua
@@ -9,13 +9,13 @@ M.get_cookie = function(request, settings)
     return nil
   end
 end
-M.set_cookie = function(server, frontend, settings)
+M.set_cookie = function(request, server, frontend, settings)
   local name = settings.COOKIE
   local value = base64.encode(server)
   local path = M.extract_path(frontend)
-  local cookie = tostring(url.escape(name)) .. "=" .. tostring(url.escape(value)) .. "; Path=" .. tostring(path) .. "; HttpOnly"
-  ngx.log(ngx.DEBUG, "Setting sticky server: " .. tostring(value) .. " (Path=" .. tostring(path) .. ")")
-  return ngx.req.set_header('Set-Cookie', cookie)
+  local cookie = tostring(url.escape(value)) .. "; Path=" .. tostring(path) .. "; HttpOnly"
+  ngx.log(ngx.DEBUG, "Setting sticky server: " .. tostring(server) .. " (Path=" .. tostring(path) .. ")")
+  request.cookies[settings.COOKIE] = cookie
 end
 M.clear_cookie = function(request, settings)
   request.cookies[settings.COOKIE] = nil
@@ -40,7 +40,7 @@ M.post = function(request, session, settings)
   if session.server ~= nil then
     local current_server = M.extract_domain(session.server)
     if sticky_server ~= current_server then
-      return M.set_cookie(current_server, session.frontend, settings)
+      return M.set_cookie(request, current_server, session.frontend, settings)
     end
   end
 end

--- a/lua/src/lib/plugins/stickiness.lua
+++ b/lua/src/lib/plugins/stickiness.lua
@@ -13,9 +13,9 @@ M.set_cookie = function(request, server, frontend, settings)
   local name = settings.COOKIE
   local value = base64.encode(server)
   local path = M.extract_path(frontend)
-  local cookie = tostring(url.escape(value)) .. "; Path=" .. tostring(path) .. "; HttpOnly"
+  local cookie = tostring(url.escape(name)) .. "=" .. tostring(url.escape(value)) .. "; Path=" .. tostring(path) .. "; HttpOnly"
   ngx.log(ngx.DEBUG, "Setting sticky server: " .. tostring(server) .. " (Path=" .. tostring(path) .. ")")
-  request.cookies[settings.COOKIE] = cookie
+  ngx.headers['Set-Cookie'] = cookie
 end
 M.clear_cookie = function(request, settings)
   request.cookies[settings.COOKIE] = nil

--- a/spec/plugins/stickiness_spec.moon
+++ b/spec/plugins/stickiness_spec.moon
@@ -18,7 +18,7 @@ _G.ngx = {
     NOTICE: 'NOTICE'
     WARN: 'WARN'
     ERR: 'ERROR'
-    headers: {}
+    header: {}
     log: (lvl, msg) ->
         print(lvl .. ": " .. msg)
     req: {
@@ -57,7 +57,7 @@ describe "stickiness plugin", ->
             cookie = base64.encode(cookie)
         return {
             req: {
-                headers: headers
+                header: headers
                 parsed_url: url.parse(u)
             }
             cookies: {
@@ -75,7 +75,7 @@ describe "stickiness plugin", ->
 
         response = plugin.post(request, session, settings)
 
-        assert.are.same(ngx.headers['Set-Cookie'], "shinyapps_session=#{base64.encode('localhost:12345')}; Path=/foo/; HttpOnly")
+        assert.are.same(ngx.header['Set-Cookie'], "shinyapps_session=#{base64.encode('localhost:12345')}; Path=/foo/; HttpOnly")
 
 
     it "should use existing sticky session cookie if its valid", () ->
@@ -90,7 +90,7 @@ describe "stickiness plugin", ->
 
         response = plugin.post(request, session, settings)
 
-        assert.are.same(ngx.headers['Set-Cookie'], cookie)
+        assert.are.same(ngx.header['Set-Cookie'], cookie)
 
     it "should use valid servers in the sticky session cookie", () ->
 

--- a/spec/plugins/stickiness_spec.moon
+++ b/spec/plugins/stickiness_spec.moon
@@ -75,12 +75,12 @@ describe "stickiness plugin", ->
 
         response = plugin.post(request, session, settings)
 
-        assert.are.same(request.cookies['shinyapps_session'], "#{base64.encode('localhost:12345')}; Path=/foo/; HttpOnly")
+        assert.are.same(ngx.headers['Set-Cookie'], "shinyapps_session=#{base64.encode('localhost:12345')}; Path=/foo/; HttpOnly")
 
 
     it "should use existing sticky session cookie if its valid", () ->
 
-        cookie = "#{base64.encode('localhost:12345')}; Path=/; HttpOnly"
+        cookie = "shinyapps_session=#{base64.encode('localhost:12345')}; Path=/; HttpOnly"
 
         -- construct an authenticated request
         request = new_request('http://example.com/foo/bar', cookie) 
@@ -90,7 +90,7 @@ describe "stickiness plugin", ->
 
         response = plugin.post(request, session, settings)
 
-        assert.are.same(request.cookies['shinyapps_session'], cookie)
+        assert.are.same(ngx.headers['Set-Cookie'], cookie)
 
     it "should use valid servers in the sticky session cookie", () ->
 

--- a/spec/plugins/stickiness_spec.moon
+++ b/spec/plugins/stickiness_spec.moon
@@ -1,0 +1,117 @@
+-- include redx path
+package.path = package.path .. ";lua/src/lib/?.lua;lua/src/lib/plugins/?.lua"
+
+url = require 'socket.url'
+inspect = require 'inspect'
+base64 = require 'base64'
+library = require 'library'  -- from redx
+
+-- inspect module inserted into global env
+_G.inspect = inspect
+
+-- library module inserted into global env
+_G.library = library
+
+-- fake ngx module inserted into global env
+_G.ngx = {
+    DEBUG: 'DEBUG'
+    NOTICE: 'NOTICE'
+    WARN: 'WARN'
+    ERR: 'ERROR'
+    log: (lvl, msg) ->
+        print(lvl .. ": " .. msg)
+    req: {
+        clear_header: (h) ->
+        set_header: (h, v) ->
+            print(h, v)
+    }
+}
+
+-- load plugin
+plugin = require "stickiness"
+
+describe "stickiness plugin", ->
+    randomize!
+
+    -- initialize plugin settings
+    settings = {
+        COOKIE: 'shinyapps_session'
+    }
+
+    new_session = (frontend, backend, servers) ->
+        m = math.huge
+        for k in pairs(servers)
+            m = math.min(k, m)
+
+        return {
+            frontend: frontend
+            backend: backend
+            servers: servers
+            server: servers[m]
+            config: {
+                shinyapps_auth: users
+            }
+        }
+
+    new_request = (u, cookie=nil) ->
+        if cookie != nil
+            cookie = base64.encode(cookie)
+        return {
+            req: {
+                headers: headers
+                parsed_url: url.parse(u)
+            }
+            cookies: {
+                shinyapps_session: cookie
+            }
+        }
+
+    it "should set sticky session cookie", () ->
+
+        -- construct an authenticated request
+        request = new_request('http://example.com/foo/derp')
+
+        -- construct a session
+        session = new_session('example.com/foo/', 12345, {{address: 'localhost:12345'}})
+
+        m = mock(ngx)
+        response = plugin.post(request, session, settings)
+        assert.spy(m.req.set_header).was.called()
+        mock.revert(m)
+
+    it "should use existing sticky session cookie if its valid", () ->
+
+        -- construct an authenticated request
+        request = new_request('http://example.com/foo/bar', 'localhost:12345')
+
+        -- construct a session
+        session = new_session('example.com/', 12345, {{address: 'localhost:12345'}})
+
+        m = mock(ngx)
+        response = plugin.post(request, session, settings)
+        assert.spy(m.req.set_header).was.not.called()
+        mock.revert(m)
+
+    it "should use valid servers in the sticky session cookie", () ->
+
+        -- construct an authenticated request
+        request = new_request('http://example.com/', 'localhost:12345')
+
+        -- construct a session
+        session = new_session('example.com', 12345, {{address: 'localhost:12345'}})
+
+        result = plugin.balance(request, session, settings)
+        assert.are.same({address: 'localhost:12345'}, result)
+
+    it "should ignore invalid servers in the sticky session cookie", () ->
+
+        -- construct an authenticated request
+        request = new_request('http://example.com/', 'localhost:56789')
+
+        -- construct a session
+        session = new_session('example.com', 12345, {{address: 'localhost:12345'}})
+
+        result = plugin.balance(request, session, settings)
+        assert.are.same({{address: 'localhost:12345'}}, result)
+        assert.are.same(request.cookies['shinyapps_session'], nil)
+

--- a/spec/plugins/stickiness_spec.moon
+++ b/spec/plugins/stickiness_spec.moon
@@ -47,7 +47,7 @@ describe "stickiness plugin", ->
             frontend: frontend
             backend: backend
             servers: servers
-            server: servers[m]
+            server: servers[m].address
             config: {
                 shinyapps_auth: users
             }

--- a/src/bin/main.moon
+++ b/src/bin/main.moon
@@ -89,22 +89,8 @@ process_response = (response) ->
         ngx.exit(response['status'])
     else
         return layout: false
-        
 
 class extends lapis.Application
-    cookie_attributes: (name, value) =>
-        path = @req.parsed_url['path']
-        path_parts = library.split path, '/'
-        p = ''
-        count = 0
-        for k,v in pairs path_parts do
-            unless v == nil or v == ''
-                if count < (config.max_path_length)
-                    count += 1
-                    p = p .. "/#{v}"
-        if p == ''
-            p = '/'
-        "Max-Age=#{config.session_length}; Path=#{p}; HttpOnly"
 
     '/': =>
         process_response(process_request(@))

--- a/src/lib/plugins/stickiness.moon
+++ b/src/lib/plugins/stickiness.moon
@@ -20,7 +20,7 @@ M.set_cookie = (server, frontend, settings) ->
 
     -- encode cookie
     name = settings.COOKIE
-    value = base64.encode(server.address)
+    value = base64.encode(server)
     path = M.extract_path(frontend) -- extract path from frontend URL
     cookie = "#{url.escape(name)}=#{url.escape(value)}; Path=#{path}; HttpOnly"
 
@@ -59,7 +59,7 @@ M.post = (request, session, settings) ->
     if session.server != nil
         current_server = M.extract_domain(session.server)
         if sticky_server != current_server
-            M.set_cookie(session.server, session.frontend, settings)
+            M.set_cookie(current_server, session.frontend, settings)
 
 M.extract_domain = (url) ->
     if not string.match(url, '/')

--- a/src/lib/plugins/stickiness.moon
+++ b/src/lib/plugins/stickiness.moon
@@ -57,7 +57,7 @@ M.post = (request, session, settings) ->
 
     -- set new sticky session cookie if changed
     if session.server != nil
-        current_server = M.extract_domain(session.server.address)
+        current_server = M.extract_domain(session.server)
         if sticky_server != current_server
             M.set_cookie(session.server, session.frontend, settings)
 

--- a/src/lib/plugins/stickiness.moon
+++ b/src/lib/plugins/stickiness.moon
@@ -1,19 +1,65 @@
--- Stickiness 
+-- Stickiness
 -- This plugin tries to send the same requester to the same backend each time by
 -- saving which backend they were sent to last in a cookie.
 
+url = require 'socket.url'
+base64 = require 'base64'
+
 M = {}
 
-M.balance = (request, session, param) ->
-    for server in *session['servers']
-        if request.session.backend == M.extract_domain(server['address'])
-            return server
+M.get_cookie = (request, settings) ->
+
+    -- get the sticky session cookie
+    cookie = request.cookies[settings.COOKIE]
+    if cookie != nil
+        return base64.decode(cookie)
+    else
+        return nil
+
+M.set_cookie = (server, frontend, settings) ->
+
+    -- encode cookie
+    name = settings.COOKIE
+    value = base64.encode(server.address)
+    path = M.extract_path(frontend) -- extract path from frontend URL
+    cookie = "#{url.escape(name)}=#{url.escape(value)}; Path=#{path}; HttpOnly"
+
+    -- set the sticky session cookie
+    ngx.log(ngx.DEBUG, "Setting sticky server: #{value} (Path=#{path})")
+    ngx.req.set_header('Set-Cookie', cookie)
+
+M.clear_cookie = (request, settings) ->
+
+    -- delete the sticky session cookie
+    request.cookies[settings.COOKIE] = nil
+
+M.balance = (request, session, settings) ->
+
+    -- if a sticky server is set, iterate servers until we find the matching one
+    sticky_server = M.get_cookie(request, settings)
+    if sticky_server != nil
+
+        for server in *session.servers
+            if sticky_server == M.extract_domain(server.address)
+                return server
+
+        ngx.log(ngx.WARN, "Server not found matching address: #{sticky_server}")
+
+        -- cookie might be bad, clear it
+        M.clear_cookie(request, settings)
+
     return session['servers']
 
-M.post = (request, session, param) ->
-    if session['server']
-        -- update cookie
-        request.session.backend = M.extract_domain(session['server'])
+M.post = (request, session, settings) ->
+
+    -- get existing session cookie
+    sticky_server = M.get_cookie(request, settings)
+
+    -- set new sticky session cookie if changed
+    if session.server != nil
+        current_server = M.extract_domain(session.server.address)
+        if sticky_server != current_server
+            M.set_cookie(session.server, session.frontend, settings)
 
 M.extract_domain = (url) ->
     if not string.match(url, '/')
@@ -22,5 +68,12 @@ M.extract_domain = (url) ->
         location_index = string.find(url,'/')
         domain = string.sub(url, 1, (location_index - 1))
         return domain
+
+M.extract_path = (url) ->
+    i = string.find(url, '/')
+    if i != nil
+        string.sub(url, i)
+    else
+        return '/'
 
 return M

--- a/src/lib/plugins/stickiness.moon
+++ b/src/lib/plugins/stickiness.moon
@@ -16,17 +16,17 @@ M.get_cookie = (request, settings) ->
     else
         return nil
 
-M.set_cookie = (server, frontend, settings) ->
+M.set_cookie = (request, server, frontend, settings) ->
 
     -- encode cookie
     name = settings.COOKIE
     value = base64.encode(server)
     path = M.extract_path(frontend) -- extract path from frontend URL
-    cookie = "#{url.escape(name)}=#{url.escape(value)}; Path=#{path}; HttpOnly"
+    cookie = "#{url.escape(value)}; Path=#{path}; HttpOnly"
 
     -- set the sticky session cookie
-    ngx.log(ngx.DEBUG, "Setting sticky server: #{value} (Path=#{path})")
-    ngx.req.set_header('Set-Cookie', cookie)
+    ngx.log(ngx.DEBUG, "Setting sticky server: #{server} (Path=#{path})")
+    request.cookies[settings.COOKIE] = cookie
 
 M.clear_cookie = (request, settings) ->
 
@@ -59,7 +59,7 @@ M.post = (request, session, settings) ->
     if session.server != nil
         current_server = M.extract_domain(session.server)
         if sticky_server != current_server
-            M.set_cookie(current_server, session.frontend, settings)
+            M.set_cookie(request, current_server, session.frontend, settings)
 
 M.extract_domain = (url) ->
     if not string.match(url, '/')

--- a/src/lib/plugins/stickiness.moon
+++ b/src/lib/plugins/stickiness.moon
@@ -10,9 +10,13 @@ M = {}
 M.get_cookie = (request, settings) ->
 
     -- get the sticky session cookie
-    cookie = request.cookies[settings.COOKIE]
-    if cookie != nil
-        return base64.decode(cookie)
+    raw = request.cookies[settings.COOKIE]
+    if raw != nil
+        ok, cookie = pcall(base64.decode, raw)
+        ngx.log(ngx.WARN, "Error decoding cookie: #{raw}")
+        if ok
+            return cookie
+        return nil
     else
         return nil
 

--- a/src/lib/plugins/stickiness.moon
+++ b/src/lib/plugins/stickiness.moon
@@ -22,11 +22,11 @@ M.set_cookie = (request, server, frontend, settings) ->
     name = settings.COOKIE
     value = base64.encode(server)
     path = M.extract_path(frontend) -- extract path from frontend URL
-    cookie = "#{url.escape(value)}; Path=#{path}; HttpOnly"
+    cookie = "#{url.escape(name)}=#{url.escape(value)}; Path=#{path}; HttpOnly"
 
     -- set the sticky session cookie
     ngx.log(ngx.DEBUG, "Setting sticky server: #{server} (Path=#{path})")
-    request.cookies[settings.COOKIE] = cookie
+    ngx.headers['Set-Cookie'] = cookie -- manually set response header
 
 M.clear_cookie = (request, settings) ->
 

--- a/src/lib/plugins/stickiness.moon
+++ b/src/lib/plugins/stickiness.moon
@@ -26,7 +26,7 @@ M.set_cookie = (request, server, frontend, settings) ->
 
     -- set the sticky session cookie
     ngx.log(ngx.DEBUG, "Setting sticky server: #{server} (Path=#{path})")
-    ngx.headers['Set-Cookie'] = cookie -- manually set response header
+    ngx.header['Set-Cookie'] = cookie -- manually set response header
 
 M.clear_cookie = (request, settings) ->
 


### PR DESCRIPTION
This PR fixes a bug in the sticky session plugin. 

Currently distinct sticky session cookies are being set for every path component of the request URI. For example, if a frontend is defined as `example.com/foo/`, and a requests for `example.com/foo/` is made, a sticky session cookie is set for for `example.com/foo/`. If a second request for `example.com/foo/bar/` comes in, a second cookie is set for `example.com/foo/bar/`. The bowser treats these as unique cookies (which they are because the paths are different). Eventually after enough requests to unique paths, the browser may not allow any more cookies to be set, which may cause it lose other valid cookies (such as an authentication cookie).

The fix is to only set the cookie for the path of canonical frontend url.