### PR TITLE
Bump the version of busted

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - sudo luarocks install luabitop 1.0.2-2
   - sudo luarocks install luasec 0.5-2 OPENSSL_DIR=/usr OPENSSL_LIBDIR=/usr/lib/x86_64-linux-gnu 
   - sudo luarocks install luafilesystem 1.6.2-2
-  - sudo luarocks install busted 2.0.rc11-0
+  - sudo luarocks install busted 2.0.rc12-1
   - sudo luarocks install lua-cjson 2.1.0-1
   - sudo luarocks install lapis 1.0.4-1
   - sudo luarocks install moonscript 0.2.6-1


### PR DESCRIPTION
Similar to #21, the declaration of busted's dependency upon lua_cliargs was [broken](https://github.com/Olivine-Labs/busted/issues/520)